### PR TITLE
remove vscode-npm-script (Deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "tintinweb.vscode-inline-bookmarks",
         "tintinweb.solidity-metrics",
         "streetsidesoftware.code-spell-checker",
-        "eg2.vscode-npm-script",
         "ryu1kn.partial-diff",
         "eamodio.gitlens",
         "gimenete.github-linker",


### PR DESCRIPTION
The extension is no longer being maintained. Support for running npm scripts is now provided by VS Code. For more info check their [README.md](https://github.com/Microsoft/vscode-npm-scripts?tab=readme-ov-file#node-npm)